### PR TITLE
Add a json schema definition/validation for the embedly data #25

### DIFF
--- a/embedly/embedly/app.py
+++ b/embedly/embedly/app.py
@@ -41,4 +41,8 @@ def create_app(redis_client=None):
     app.config['SENTRY_DSN'] = os.environ.get('SENTRY_DSN', '')
     app.sentry = Sentry(app)
 
+    app.config['BLOCKED_DOMAINS'] = [
+        'embedly.com',
+    ]
+
     return app

--- a/embedly/embedly/schema.py
+++ b/embedly/embedly/schema.py
@@ -1,0 +1,108 @@
+from urlparse import urlsplit
+
+from flask import current_app
+from marshmallow import Schema, fields
+from publicsuffix import PublicSuffixList
+
+
+PSL = PublicSuffixList()
+
+
+class AuthorSchema(Schema):
+    url = fields.Url(allow_none=True)
+    name = fields.Str(allow_none=True)
+
+
+class AppLinkSchema(Schema):
+    namespace = fields.Str(allow_none=True)
+    package = fields.Str(allow_none=True)
+    path = fields.Str(allow_none=True)
+    type = fields.Str(allow_none=True)
+
+
+class EntitySchema(Schema):
+    count = fields.Int(allow_none=True)
+    name = fields.Str(allow_none=True)
+
+
+class KeywordSchema(Schema):
+    score = fields.Int(allow_none=True)
+    name = fields.Str(allow_none=True)
+
+
+class ColorSchema(Schema):
+    color = fields.List(fields.Int)
+    weight = fields.Float(allow_none=True)
+
+
+class MediaSchema(Schema):
+    author_name = fields.Str(allow_none=True)
+    author_url = fields.Url(allow_none=True)
+    cache_age = fields.Int(allow_none=True)
+    description = fields.Str(allow_none=True)
+    provider_name = fields.Str(allow_none=True)
+    provider_url = fields.Url(allow_none=True)
+    thumbnail_height = fields.Int(allow_none=True)
+    thumbnail_url = fields.Url(allow_none=True)
+    thumbnail_width = fields.Int(allow_none=True)
+    title = fields.Str(allow_none=True)
+    type = fields.Str(allow_none=True)
+    version = fields.Str(allow_none=True)
+
+
+class ImageSchema(Schema):
+    caption = fields.Str(allow_none=True)
+    colors = fields.Nested(ColorSchema, many=True)
+    entropy = fields.Float(allow_none=True)
+    height = fields.Int(allow_none=True)
+    size = fields.Int(allow_none=True)
+    url = fields.Url(allow_none=True)
+    width = fields.Int(allow_none=True)
+
+
+class EmbedlyURLSchema(Schema):
+    app_links = fields.Nested(AppLinkSchema, many=True)
+    authors = fields.Nested(AuthorSchema, many=True)
+    cache_age = fields.Int(allow_none=True)
+    content = fields.Str(allow_none=True)
+    description = fields.Str(allow_none=True)
+    embeds = fields.Nested(MediaSchema, many=True)
+    entities = fields.Nested(EntitySchema, many=True)
+    favicon_colors = fields.Nested(ColorSchema, many=True, allow_none=True)
+    favicon_url = fields.Url(allow_none=True)
+    images = fields.Nested(ImageSchema, many=True)
+    keywords = fields.Nested(KeywordSchema, many=True)
+    language = fields.Str(allow_none=True)
+    lead = fields.Str(allow_none=True)
+    media = fields.Nested(MediaSchema)
+    offset = fields.Int(allow_none=True)
+    original_url = fields.Url(allow_none=True)
+    provider_display = fields.Str(allow_none=True)
+    provider_name = fields.Str(allow_none=True)
+    provider_url = fields.Url(allow_none=True)
+    published = fields.Int(allow_none=True)
+    related = fields.Nested(MediaSchema, many=True)
+    safe = fields.Bool(allow_none=True)
+    title = fields.Str(allow_none=True)
+    type = fields.Str(allow_none=True)
+    url = fields.Url(allow_none=True)
+
+    def load(self, data):
+        validated = super(EmbedlyURLSchema, self).load(data)
+
+        def get_domain(url):
+            return PSL.get_public_suffix(urlsplit(url).netloc)
+
+        original_domain = get_domain(validated.data.get('original_url', ''))
+
+        disallowed_domains = [
+            domain for domain in current_app.config['BLOCKED_DOMAINS']
+            if domain != original_domain
+        ]
+
+        validated.data['images'] = [
+            image for image in validated.data.get('images', [])
+            if get_domain(image.get('url', '')) not in disallowed_domains
+        ]
+
+        return validated

--- a/embedly/embedly/tests/base.py
+++ b/embedly/embedly/tests/base.py
@@ -1,11 +1,112 @@
+import copy
 from unittest import TestCase
 
 import mock
 
+from embedly.app import create_app
 
-class MockTest(TestCase):
+
+EMBEDLY_TEST_DATA = {
+    'app_links': [{
+        'namespace': 'Example',
+        'package': 'Example',
+        'path': '/example/',
+        'type': 'example',
+    }],
+    'authors': [{
+        'name': 'Julius Caeser',
+        'url': 'https://www.example.com/julius/',
+    }],
+    'cache_age': 78022,
+    'content': '<html><body>Hello!</body></html>',
+    'description': 'Example web site',
+    'embeds': [{
+        'author_name': 'Julius Caeser',
+        'author_url': 'https://www.example.com/julius/',
+        'cache_age': 123,
+        'description': 'Stuff!',
+        'provider_name': 'Things!',
+        'provider_url': 'https://www.example.com/',
+        'thumbnail_height': 123,
+        'thumbnail_url': 'https://www.example.com/image.jpg',
+        'thumbnail_width': 123,
+        'title': 'This and that.',
+        'type': 'html',
+        'version': '1.0',
+    }],
+    'entities': [{
+        'name': 'Person',
+        'count': 1,
+    }],
+    'favicon_colors': [{
+        'color': [208, 226, 240],
+        'weight': 0.1926269531,
+    }],
+    'favicon_url': 'https://www.example.com/favicon.ico',
+    'images': [{
+        'caption': 'An image',
+        'colors': [{
+            'color': [208, 226, 240],
+            'weight': 0.1926269531,
+        }],
+        'entropy': 0.1,
+        'height': 100,
+        'size': 12345,
+        'url': 'https://www.example.com/image.jpg',
+        'width': 100,
+    }],
+    'keywords': [{
+        'name': 'Person',
+        'score': 1,
+    }],
+    'language': 'English',
+    'lead': 'Leading in!',
+    'media': {
+        'author_name': 'Julius Caeser',
+        'author_url': 'https://www.example.com/julius/',
+        'cache_age': 123,
+        'description': 'Stuff!',
+        'provider_name': 'Things!',
+        'provider_url': 'https://www.example.com/',
+        'thumbnail_height': 123,
+        'thumbnail_url': 'https://www.example.com/image.jpg',
+        'thumbnail_width': 123,
+        'title': 'This and that.',
+        'type': 'html',
+        'version': '1.0',
+    },
+    'offset': 12345,
+    'original_url': 'http://www.example.com',
+    'provider_display': 'www.example.com',
+    'provider_name': 'Reddit',
+    'provider_url': 'https://www.example.com',
+    'published': 1459186964000,
+    'related': [{
+        'author_name': 'Julius Caeser',
+        'author_url': 'https://www.example.com/julius/',
+        'cache_age': 123,
+        'description': 'Stuff!',
+        'provider_name': 'Things!',
+        'provider_url': 'https://www.example.com/',
+        'thumbnail_height': 123,
+        'thumbnail_url': 'https://www.example.com/image.jpg',
+        'thumbnail_width': 123,
+        'title': 'This and that.',
+        'type': 'html',
+        'version': '1.0',
+    }],
+    'safe': True,
+    'title': 'Example web site',
+    'type': 'html',
+    'url': 'https://www.example.com/'
+}
+
+
+class AppTest(TestCase):
 
     def setUp(self):
+        super(AppTest, self).setUp()
+
         mock_requests_get_patcher = mock.patch(
             'embedly.extract.requests.get')
         self.mock_requests_get = mock_requests_get_patcher.start()
@@ -15,10 +116,18 @@ class MockTest(TestCase):
         self.mock_redis.get.return_value = None
         self.mock_redis.set.return_value = None
 
-        super(MockTest, self).setUp()
+        self.app = create_app(redis_client=self.mock_redis)
+        self.app.config['DEBUG'] = True
+        self.app.config['TESTING'] = True
+
+        self.client = self.app.test_client()
+
+        self.test_data = copy.copy(EMBEDLY_TEST_DATA)
 
     def get_mock_url_data(self, url):
-        return {'original_url': url}
+        embedly_data = copy.copy(EMBEDLY_TEST_DATA)
+        embedly_data['original_url'] = url
+        return embedly_data
 
     def get_mock_urls_data(self, urls):
         return [self.get_mock_url_data(url) for url in urls]

--- a/embedly/embedly/tests/test_schema.py
+++ b/embedly/embedly/tests/test_schema.py
@@ -1,0 +1,56 @@
+from embedly.tests.base import AppTest
+from embedly.schema import EmbedlyURLSchema
+
+
+class TestEmbedlyURLSchema(AppTest):
+
+    def setUp(self):
+        super(TestEmbedlyURLSchema, self).setUp()
+        self.schema = EmbedlyURLSchema()
+
+    def test_validator_accepts_valid_data(self):
+        with self.app.app_context():
+            validated = self.schema.load(self.test_data)
+            self.assertEqual(validated.data, self.test_data)
+            self.assertEqual(validated.errors, {})
+
+    def test_validator_removes_images_with_blocked_domain_and_subdomains(self):
+        self.app.config['BLOCKED_DOMAINS'] = ['blockeddomain.com']
+
+        blocked_image = {'url': 'https://blockeddomain.com/image.jpg'}
+        blocked_subdomain_image = {
+            'url': 'https://subdomain.blockeddomain.com/image.jpg',
+        }
+        allowed_image = {'url': 'https://alloweddomain.com/image.jpg'}
+
+        self.test_data['images'] = [
+            blocked_image,
+            blocked_subdomain_image,
+            allowed_image,
+        ]
+
+        with self.app.app_context():
+            validated = self.schema.load(self.test_data)
+
+        self.assertIn(allowed_image, validated.data['images'])
+        self.assertNotIn(blocked_image, validated.data['images'])
+        self.assertNotIn(blocked_subdomain_image, validated.data['images'])
+
+    def test_valdiator_accepts_blocked_domains_for_same_url_domain(self):
+        self.app.config['BLOCKED_DOMAINS'] = ['blockeddomain.com']
+
+        self.test_data['original_url'] = 'https://blockeddomain.com/beep/'
+
+        blocked_image = {'url': 'https://blockeddomain.com/image.jpg'}
+        allowed_image = {'url': 'https://alloweddomain.com/image.jpg'}
+
+        self.test_data['images'] = [
+            blocked_image,
+            allowed_image,
+        ]
+
+        with self.app.app_context():
+            validated = self.schema.load(self.test_data)
+
+        self.assertIn(allowed_image, validated.data['images'])
+        self.assertIn(blocked_image, validated.data['images'])

--- a/embedly/requirements.txt
+++ b/embedly/requirements.txt
@@ -3,8 +3,10 @@ Flask==0.10.1
 blinker==1.4
 gevent==1.0.2
 gunicorn==19.4.5
+marshmallow==2.6.0
 mock==1.3.0
 nose==1.3.7
+publicsuffix2==2.1.0
 raven==5.12.0
 redis==2.10.5
 requests==2.9.1


### PR DESCRIPTION
This will add support for embedly data being validated at the json structure/field level, as well as at a higher level.  The current supported logic is:

- If we receive images whose urls contain a set of specified blacklisted domains (specifically the embedly domains) for a site url which does not match those domains (ie a non embedly site with an embedly proxied image) we will drop those images

r? @pdehaan @oyiptong 