### PR TITLE
Checks json mimetype within content-type header

### DIFF
--- a/embedly/embedly/api/views.py
+++ b/embedly/embedly/api/views.py
@@ -54,7 +54,7 @@ def extract_urls_v2():
             mimetype='application/json',
         ))
 
-    if request.content_type != 'application/json':
+    if 'application/json' not in request.content_type:
         fail(400, 'The Content-Type header must be set to application/json')
 
     try:


### PR DESCRIPTION
Checks if 'application/json' is contained within the 'Content-Type' header. Some application clients append the charset to the content-type which causes requests to fail (in my case, with the [OkHttp3 library](https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/RequestBody.java#L52) which I was using with a prototype).

For example, `Content-Type: application/json; charset=utf-8` is a valid content type but fails against the proxy.