### PR TITLE
Rate limit by domain #71

### DIFF
--- a/app/proxy/tests/base.py
+++ b/app/proxy/tests/base.py
@@ -39,6 +39,13 @@ class AppTest(TestCase):
         self.mock_requests_post = mock_requests_post_patcher.start()
         self.addCleanup(mock_requests_post_patcher.stop)
 
+        self.mock_domain_limiter = mock.Mock()
+        mock_limiter_patcher = mock.patch(
+            'proxy.metadata.rratelimit.SimpleLimiter')
+        mock_simple_limiter = mock_limiter_patcher.start()
+        mock_simple_limiter.return_value = self.mock_domain_limiter
+        self.addCleanup(mock_limiter_patcher.stop)
+
         self.mock_redis = mock.Mock()
         self.mock_redis.get.return_value = None
         self.mock_redis.setex.return_value = None

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -16,4 +16,5 @@ raven==5.12.0
 redis==2.10.5
 requests==2.9.1
 rq==0.6.0
+rratelimit==0.0.4
 statsd==3.2.1


### PR DESCRIPTION
Rate limit every requested URL by its domain at a rate of 10/s across all callers/requests to prevent our service accidentally flooding a given domain with requests.